### PR TITLE
Optimize Widget Update Interval

### DIFF
--- a/app/src/main/java/com/leanbitlab/lwidget/AwidgetProvider.kt
+++ b/app/src/main/java/com/leanbitlab/lwidget/AwidgetProvider.kt
@@ -138,8 +138,8 @@ class AwidgetProvider : AppWidgetProvider() {
             android.app.PendingIntent.FLAG_UPDATE_CURRENT or android.app.PendingIntent.FLAG_IMMUTABLE
         )
         
-        // 5 minutes
-        val intervalMillis = 5L * 60L * 1000L
+        // 1 minute
+        val intervalMillis = 1L * 60L * 1000L
         
         alarmManager.setInexactRepeating(
             android.app.AlarmManager.RTC,


### PR DESCRIPTION
Changes the widget's scheduled update interval from 5 minutes to 1 minute.
The update uses `AlarmManager.RTC` so the device does not wake up from sleep to perform the update, thus saving battery power while still providing more accurate battery, temperature, and data statuses during device usage without needing an active foreground service (keep-alive feature).

---
*PR created automatically by Jules for task [11134525131835875491](https://jules.google.com/task/11134525131835875491) started by @LeanBitLab*