### PR TITLE
🧹 fix: replace hardcoded permission strings with constants

### DIFF
--- a/app/src/main/java/com/leanbitlab/lwidget/AwidgetProvider.kt
+++ b/app/src/main/java/com/leanbitlab/lwidget/AwidgetProvider.kt
@@ -165,6 +165,8 @@ class AwidgetProvider : AppWidgetProvider() {
 
     companion object {
         const val ACTION_BATTERY_UPDATE = "com.leanbitlab.lwidget.ACTION_BATTERY_UPDATE"
+        const val PERMISSION_READ_TASKS_ORG = "org.tasks.permission.READ_TASKS"
+        const val PERMISSION_READ_TASKS_ASTRID = "com.todoroo.astrid.READ"
 
         // Suspended function called from Coroutine
         fun updateAppWidget(context: Context, appWidgetManager: AppWidgetManager, appWidgetId: Int, mode: UpdateMode = UpdateMode.FULL) {
@@ -236,7 +238,7 @@ class AwidgetProvider : AppWidgetProvider() {
             val sizeStorage = prefs.getFloat("size_storage", 14f)
 
             var showTasks = prefs.getBoolean("show_tasks", false)
-            if (showTasks && androidx.core.content.ContextCompat.checkSelfPermission(context, "org.tasks.permission.READ_TASKS") != android.content.pm.PackageManager.PERMISSION_GRANTED) {
+            if (showTasks && androidx.core.content.ContextCompat.checkSelfPermission(context, PERMISSION_READ_TASKS_ORG) != android.content.pm.PackageManager.PERMISSION_GRANTED) {
                 showTasks = false
             }
             val sizeTasks = prefs.getFloat("size_tasks", 14f)
@@ -1095,8 +1097,8 @@ class AwidgetProvider : AppWidgetProvider() {
             )
             
             // Debugging: Check permission again contextually
-            val hasPerm = context.checkSelfPermission("org.tasks.permission.READ_TASKS") == android.content.pm.PackageManager.PERMISSION_GRANTED ||
-                          context.checkSelfPermission("com.todoroo.astrid.READ") == android.content.pm.PackageManager.PERMISSION_GRANTED
+            val hasPerm = context.checkSelfPermission(PERMISSION_READ_TASKS_ORG) == android.content.pm.PackageManager.PERMISSION_GRANTED ||
+                          context.checkSelfPermission(PERMISSION_READ_TASKS_ASTRID) == android.content.pm.PackageManager.PERMISSION_GRANTED
             
             if (!hasPerm) {
                  views.setTextViewText(eventViews[0], "Missing Permission")

--- a/app/src/main/java/com/leanbitlab/lwidget/MainActivity.kt
+++ b/app/src/main/java/com/leanbitlab/lwidget/MainActivity.kt
@@ -193,7 +193,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         // Check Tasks
-        if (prefs.getBoolean("show_tasks", false) && ContextCompat.checkSelfPermission(this, "org.tasks.permission.READ_TASKS") != PackageManager.PERMISSION_GRANTED) {
+        if (prefs.getBoolean("show_tasks", false) && ContextCompat.checkSelfPermission(this, AwidgetProvider.PERMISSION_READ_TASKS_ORG) != PackageManager.PERMISSION_GRANTED) {
              prefs.edit().putBoolean("show_tasks", false).apply()
              findViewById<View>(R.id.row_tasks_toggle).findViewById<com.google.android.material.switchmaterial.SwitchMaterial>(R.id.row_switch).isChecked = false
              findViewById<View>(R.id.row_tasks_size).visibility = View.GONE
@@ -1083,8 +1083,8 @@ class MainActivity : AppCompatActivity() {
                     }.show()
                     return@setOnCheckedChangeListener
                 }
-                if (ContextCompat.checkSelfPermission(this, "org.tasks.permission.READ_TASKS") != PackageManager.PERMISSION_GRANTED) {
-                    ActivityCompat.requestPermissions(this, arrayOf("org.tasks.permission.READ_TASKS"), 101)
+                if (ContextCompat.checkSelfPermission(this, AwidgetProvider.PERMISSION_READ_TASKS_ORG) != PackageManager.PERMISSION_GRANTED) {
+                    ActivityCompat.requestPermissions(this, arrayOf(AwidgetProvider.PERMISSION_READ_TASKS_ORG), 101)
                 }
                 if (checkLimit()) {
                     eventsSwitch.isChecked = false


### PR DESCRIPTION
### 🎯 What:
Replaced hardcoded permission string literals `"org.tasks.permission.READ_TASKS"` and `"com.todoroo.astrid.READ"` with constants `PERMISSION_READ_TASKS_ORG` and `PERMISSION_READ_TASKS_ASTRID` in `AwidgetProvider.kt`. Also updated `MainActivity.kt` to use the centralized constant from `AwidgetProvider`.

### 💡 Why:
Using constants for permission strings improves maintainability and readability. It centralizes these values, making it easier to update them in the future and reducing the risk of typos.

### ✅ Verification:
- Verified that all hardcoded instances identified by `grep` were replaced.
- Manually reviewed the modified code sections for correctness.
- Ensured the code structure follows Kotlin conventions for constants.

### ✨ Result:
Improved code health and maintainability by removing hardcoded literals and centralizing external permission strings.

---
*PR created automatically by Jules for task [16528227458508642490](https://jules.google.com/task/16528227458508642490) started by @LeanBitLab*