### PR TITLE
🔒 Fix insecure application configuration (allowBackup)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,7 +44,7 @@
     </queries>
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"


### PR DESCRIPTION
🎯 **What:** Fixed an insecure application configuration in `app/src/main/AndroidManifest.xml` by setting `android:allowBackup` to `false`.
⚠️ **Risk:** When `android:allowBackup` is true, application data can be backed up and extracted (e.g. via adb backup), potentially exposing sensitive local data or preferences.
🛡️ **Solution:** Disabled application backup by setting `android:allowBackup="false"` in the application block.

---
*PR created automatically by Jules for task [12104342324206650736](https://jules.google.com/task/12104342324206650736) started by @LeanBitLab*