### PR TITLE
feat: add first-time onboarding setup activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -62,6 +62,11 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".SetupActivity"
+            android:exported="false"
+            android:theme="@style/Theme.Lwidget" />
+
         <receiver android:name=".AwidgetProvider"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/com/leanbitlab/lwidget/MainActivity.kt
+++ b/app/src/main/java/com/leanbitlab/lwidget/MainActivity.kt
@@ -98,6 +98,12 @@ class MainActivity : AppCompatActivity() {
 
         prefs = getSharedPreferences("com.leanbitlab.lwidget.PREFS", Context.MODE_PRIVATE)
 
+        if (prefs.getBoolean("is_first_launch", true)) {
+            startActivity(Intent(this, SetupActivity::class.java))
+            finish()
+            return
+        }
+
         checkAllPermissions()
         setupSections()
         

--- a/app/src/main/java/com/leanbitlab/lwidget/SetupActivity.kt
+++ b/app/src/main/java/com/leanbitlab/lwidget/SetupActivity.kt
@@ -1,0 +1,162 @@
+package com.leanbitlab.lwidget
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Bundle
+import android.widget.TextView
+import android.widget.ViewFlipper
+import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.switchmaterial.SwitchMaterial
+
+class SetupActivity : AppCompatActivity() {
+
+    private lateinit var viewFlipper: ViewFlipper
+    private lateinit var btnNext: MaterialButton
+    private lateinit var btnSkip: MaterialButton
+    private lateinit var prefs: SharedPreferences
+
+    private val requestPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { permissions ->
+        updatePermissionButtons()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        com.google.android.material.color.DynamicColors.applyToActivityIfAvailable(this)
+        setContentView(R.layout.activity_setup)
+
+        prefs = getSharedPreferences("com.leanbitlab.lwidget.PREFS", Context.MODE_PRIVATE)
+
+        viewFlipper = findViewById(R.id.setup_view_flipper)
+        btnNext = findViewById(R.id.btn_setup_next)
+        btnSkip = findViewById(R.id.btn_setup_skip)
+
+        btnSkip.setOnClickListener {
+            finishSetup()
+        }
+
+        btnNext.setOnClickListener {
+            if (viewFlipper.displayedChild < viewFlipper.childCount - 1) {
+                viewFlipper.showNext()
+                updateButtons()
+            } else {
+                finishSetup()
+            }
+        }
+
+        // Keep Alive Setup
+        val switchKeepAlive = findViewById<SwitchMaterial>(R.id.switch_setup_keep_alive)
+        switchKeepAlive.isChecked = prefs.getBoolean("keep_alive", false)
+        switchKeepAlive.setOnCheckedChangeListener { _, isChecked ->
+            if (isChecked) {
+                val neededPermissions = mutableListOf<String>()
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+                    ContextCompat.checkSelfPermission(this, Manifest.permission.ACTIVITY_RECOGNITION) != PackageManager.PERMISSION_GRANTED) {
+                    neededPermissions.add(Manifest.permission.ACTIVITY_RECOGNITION)
+                }
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                    ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+                    neededPermissions.add(Manifest.permission.POST_NOTIFICATIONS)
+                }
+                if (neededPermissions.isNotEmpty()) {
+                    requestPermissionLauncher.launch(neededPermissions.toTypedArray())
+                }
+            }
+            prefs.edit().putBoolean("keep_alive", isChecked).apply()
+        }
+
+        // Permissions Setup
+        findViewById<MaterialButton>(R.id.btn_grant_calendar).setOnClickListener {
+            requestPermissionLauncher.launch(arrayOf(Manifest.permission.READ_CALENDAR))
+        }
+
+        findViewById<MaterialButton>(R.id.btn_grant_tasks).setOnClickListener {
+            requestPermissionLauncher.launch(arrayOf(
+                "org.tasks.permission.READ_TASKS",
+                "com.todoroo.astrid.READ"
+            ))
+        }
+
+        findViewById<MaterialButton>(R.id.btn_grant_steps).setOnClickListener {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                requestPermissionLauncher.launch(arrayOf(Manifest.permission.ACTIVITY_RECOGNITION))
+            }
+        }
+
+        updateButtons()
+        updatePermissionButtons()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        updatePermissionButtons()
+    }
+
+    private fun updateButtons() {
+        if (viewFlipper.displayedChild == viewFlipper.childCount - 1) {
+            btnNext.text = getString(R.string.btn_finish)
+        } else {
+            btnNext.text = getString(R.string.btn_next)
+        }
+    }
+
+    private fun updatePermissionButtons() {
+        val btnCalendar = findViewById<MaterialButton>(R.id.btn_grant_calendar)
+        val btnTasks = findViewById<MaterialButton>(R.id.btn_grant_tasks)
+        val btnSteps = findViewById<MaterialButton>(R.id.btn_grant_steps)
+
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_CALENDAR) == PackageManager.PERMISSION_GRANTED) {
+            btnCalendar.text = "Granted"
+            btnCalendar.isEnabled = false
+            prefs.edit().putBoolean("show_events", true).apply()
+        }
+
+        val hasTasksPerm = ContextCompat.checkSelfPermission(this, "org.tasks.permission.READ_TASKS") == PackageManager.PERMISSION_GRANTED ||
+                           ContextCompat.checkSelfPermission(this, "com.todoroo.astrid.READ") == PackageManager.PERMISSION_GRANTED
+        if (hasTasksPerm) {
+            btnTasks.text = "Granted"
+            btnTasks.isEnabled = false
+            prefs.edit().putBoolean("show_tasks", true).apply()
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACTIVITY_RECOGNITION) == PackageManager.PERMISSION_GRANTED) {
+                btnSteps.text = "Granted"
+                btnSteps.isEnabled = false
+                prefs.edit().putBoolean("show_steps", true).apply()
+            }
+        } else {
+            btnSteps.text = "Granted"
+            btnSteps.isEnabled = false
+            prefs.edit().putBoolean("show_steps", true).apply()
+        }
+    }
+
+    private fun finishSetup() {
+        prefs.edit().putBoolean("is_first_launch", false).apply()
+
+        val keepAlive = prefs.getBoolean("keep_alive", false)
+        val showSteps = prefs.getBoolean("show_steps", false)
+        if (keepAlive || showSteps) {
+            val serviceIntent = Intent(this, StepCounterService::class.java)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                startForegroundService(serviceIntent)
+            } else {
+                startService(serviceIntent)
+            }
+        }
+
+        startActivity(Intent(this, MainActivity::class.java))
+        finish()
+    }
+}

--- a/app/src/main/res/layout/activity_setup.xml
+++ b/app/src/main/res/layout/activity_setup.xml
@@ -1,0 +1,314 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="?attr/colorSurface"
+    tools:context=".SetupActivity">
+
+    <!-- App Bar -->
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar_setup"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/transparent"
+        app:elevation="0dp">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_setup"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:title="Welcome to Lwidget"
+            app:titleCentered="true"
+            app:titleTextColor="?attr/colorOnSurface"/>
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <ViewFlipper
+        android:id="@+id/setup_view_flipper"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:inAnimation="@android:anim/slide_in_left"
+        android:outAnimation="@android:anim/slide_out_right">
+
+        <!-- Page 1: Welcome -->
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fillViewport="true">
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:padding="24dp">
+
+                <ImageView
+                    android:layout_width="120dp"
+                    android:layout_height="120dp"
+                    android:src="@mipmap/ic_launcher"
+                    android:layout_marginBottom="32dp"
+                    android:contentDescription="App Icon"/>
+
+                <TextView
+                    android:id="@+id/tv_setup_welcome_title"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/setup_welcome_title"
+                    android:textSize="24sp"
+                    android:textStyle="bold"
+                    android:textColor="?attr/colorOnSurface"
+                    android:gravity="center"
+                    android:layout_marginBottom="16dp"/>
+
+                <TextView
+                    android:id="@+id/tv_setup_welcome_desc"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/setup_welcome_desc"
+                    android:textSize="16sp"
+                    android:textColor="?attr/colorOnSurfaceVariant"
+                    android:gravity="center"
+                    android:lineSpacingExtra="4dp"/>
+            </LinearLayout>
+        </ScrollView>
+
+        <!-- Page 2: Keep Alive -->
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fillViewport="true">
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="24dp">
+
+                <ImageView
+                    android:layout_width="80dp"
+                    android:layout_height="80dp"
+                    android:src="@drawable/ic_alarm"
+                    app:tint="?attr/colorPrimary"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_marginBottom="24dp"/>
+
+                <TextView
+                    android:id="@+id/tv_setup_keep_alive_title"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/setup_keep_alive_title"
+                    android:textSize="24sp"
+                    android:textStyle="bold"
+                    android:textColor="?attr/colorOnSurface"
+                    android:gravity="center"
+                    android:layout_marginBottom="16dp"/>
+
+                <TextView
+                    android:id="@+id/tv_setup_keep_alive_desc"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/setup_keep_alive_desc"
+                    android:textSize="16sp"
+                    android:textColor="?attr/colorOnSurfaceVariant"
+                    android:lineSpacingExtra="4dp"
+                    android:layout_marginBottom="32dp"/>
+
+                <com.google.android.material.card.MaterialCardView
+                    style="@style/Widget.Material3.CardView.Outlined"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:cardBackgroundColor="?attr/colorSurfaceContainer">
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:padding="16dp"
+                        android:gravity="center_vertical">
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="Enable Keep Alive"
+                            android:textSize="16sp"
+                            android:textColor="?attr/colorOnSurface"
+                            android:textStyle="bold"/>
+                        <com.google.android.material.switchmaterial.SwitchMaterial
+                            android:id="@+id/switch_setup_keep_alive"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"/>
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+            </LinearLayout>
+        </ScrollView>
+
+        <!-- Page 3: Permissions -->
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fillViewport="true">
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="24dp">
+
+                <TextView
+                    android:id="@+id/tv_setup_permissions_title"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/setup_permissions_title"
+                    android:textSize="24sp"
+                    android:textStyle="bold"
+                    android:textColor="?attr/colorOnSurface"
+                    android:layout_marginBottom="16dp"/>
+
+                <TextView
+                    android:id="@+id/tv_setup_permissions_desc"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/setup_permissions_desc"
+                    android:textSize="16sp"
+                    android:textColor="?attr/colorOnSurfaceVariant"
+                    android:layout_marginBottom="24dp"/>
+
+                <!-- Calendar -->
+                <com.google.android.material.card.MaterialCardView
+                    style="@style/Widget.Material3.CardView.Outlined"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    app:cardBackgroundColor="?attr/colorSurfaceContainer">
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:padding="16dp"
+                        android:gravity="center_vertical">
+                        <ImageView
+                            android:layout_width="24dp"
+                            android:layout_height="24dp"
+                            android:src="@drawable/ic_events"
+                            app:tint="?attr/colorPrimary"
+                            android:layout_marginEnd="16dp"/>
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="Calendar Events"
+                            android:textSize="16sp"
+                            android:textColor="?attr/colorOnSurface"/>
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btn_grant_calendar"
+                            style="@style/Widget.Material3.Button.TextButton"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/btn_grant"/>
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <!-- Tasks -->
+                <com.google.android.material.card.MaterialCardView
+                    style="@style/Widget.Material3.CardView.Outlined"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    app:cardBackgroundColor="?attr/colorSurfaceContainer">
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:padding="16dp"
+                        android:gravity="center_vertical">
+                        <ImageView
+                            android:layout_width="24dp"
+                            android:layout_height="24dp"
+                            android:src="@drawable/ic_tasks"
+                            app:tint="?attr/colorPrimary"
+                            android:layout_marginEnd="16dp"/>
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="Tasks"
+                            android:textSize="16sp"
+                            android:textColor="?attr/colorOnSurface"/>
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btn_grant_tasks"
+                            style="@style/Widget.Material3.Button.TextButton"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/btn_grant"/>
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <!-- Steps -->
+                <com.google.android.material.card.MaterialCardView
+                    style="@style/Widget.Material3.CardView.Outlined"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    app:cardBackgroundColor="?attr/colorSurfaceContainer">
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:padding="16dp"
+                        android:gravity="center_vertical">
+                        <ImageView
+                            android:layout_width="24dp"
+                            android:layout_height="24dp"
+                            android:src="@drawable/ic_steps"
+                            app:tint="?attr/colorPrimary"
+                            android:layout_marginEnd="16dp"/>
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="Step Counter"
+                            android:textSize="16sp"
+                            android:textColor="?attr/colorOnSurface"/>
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btn_grant_steps"
+                            style="@style/Widget.Material3.Button.TextButton"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/btn_grant"/>
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+            </LinearLayout>
+        </ScrollView>
+    </ViewFlipper>
+
+    <!-- Bottom Action Bar -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp"
+        android:background="?attr/colorSurface"
+        android:elevation="8dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_setup_skip"
+            style="@style/Widget.Material3.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/btn_skip"
+            android:textColor="?attr/colorOnSurfaceVariant"/>
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1"/>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_setup_next"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/btn_next"/>
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,4 +76,16 @@
     <string name="color_default">Default</string>
     <string name="color_system_accent">System Accent</string>
     <string name="color_custom">Custom</string>
+
+    <!-- Setup / Onboarding -->
+    <string name="setup_welcome_title">Welcome to Lwidget</string>
+    <string name="setup_welcome_desc">A customizable widget for your home screen. Let\'s get everything set up so it works perfectly.</string>
+    <string name="setup_keep_alive_title">Keep Alive</string>
+    <string name="setup_keep_alive_desc">Some devices kill background apps to save battery, stopping widget updates. Enable Keep Alive (a lightweight background service) to prevent this.</string>
+    <string name="setup_permissions_title">Optional Permissions</string>
+    <string name="setup_permissions_desc">Grant permissions to enable optional features like calendar events, tasks, or the step counter.</string>
+    <string name="btn_next">Next</string>
+    <string name="btn_skip">Skip</string>
+    <string name="btn_finish">Finish</string>
+    <string name="btn_grant">Grant</string>
 </resources>


### PR DESCRIPTION
This commit implements an onboarding setup screen which is presented to users the first time they open the Lwidget configuration application. The onboarding process introduces the widget, requests users optionally enable the Keep Alive background service to ensure continuous widget updates, and prompts for essential permissions like Calendar, Tasks, and Activity Recognition for step counting. It provides a simple step-by-step UI with options to skip the process.

---
*PR created automatically by Jules for task [16365893186516740743](https://jules.google.com/task/16365893186516740743) started by @LeanBitLab*