### PR TITLE
Fix missing dependencies in jules-merge GitHub Action

### DIFF
--- a/.github/workflows/jules-merge-conflicts.yml
+++ b/.github/workflows/jules-merge-conflicts.yml
@@ -20,4 +20,4 @@ jobs:
 
       - name: Scan for overlapping changes
         run: |
-          npx -y --package=@google/jules-merge jules-merge scan --json '{"prs":[${{ github.event.pull_request.number }}],"repo":"${{ github.repository }}","base":"${{ github.event.pull_request.base.ref }}"}'
+          npx -y --package=@google/jules-sdk --package=@modelcontextprotocol/sdk --package=@google/jules-merge jules-merge scan --json '{"prs":[${{ github.event.pull_request.number }}],"repo":"${{ github.repository }}","base":"${{ github.event.pull_request.base.ref }}"}'

--- a/.github/workflows/jules-merge-conflicts.yml
+++ b/.github/workflows/jules-merge-conflicts.yml
@@ -19,5 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Scan for overlapping changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npx -y --package=@google/jules-sdk --package=@modelcontextprotocol/sdk --package=@google/jules-merge jules-merge scan --json '{"prs":[${{ github.event.pull_request.number }}],"repo":"${{ github.repository }}","base":"${{ github.event.pull_request.base.ref }}"}'


### PR DESCRIPTION
The `.github/workflows/jules-merge-conflicts.yml` GitHub Action was failing due to missing dependencies in the jules-merge SDK. This PR fixes the issue by explicitly adding the required missing packages (`@google/jules-sdk` and `@modelcontextprotocol/sdk`) to the `npx` execution command.

---
*PR created automatically by Jules for task [17559684391862643777](https://jules.google.com/task/17559684391862643777) started by @LeanBitLab*