### PR TITLE
Extract hardcoded colors to colors.xml

### DIFF
--- a/app/src/main/java/com/leanbitlab/lwidget/AwidgetProvider.kt
+++ b/app/src/main/java/com/leanbitlab/lwidget/AwidgetProvider.kt
@@ -322,11 +322,11 @@ class AwidgetProvider : AppWidgetProvider() {
             // Resolve background color (0=Default, 1=System Accent, 2=Custom)
             fun resolveBgColor(idx: Int, isLight: Boolean): Int {
                  return when (idx) {
-                     0 -> if (isLight) android.graphics.Color.WHITE else android.graphics.Color.parseColor("#212121")
+                     0 -> if (isLight) android.graphics.Color.WHITE else context.getColor(R.color.widget_bg_dark)
                      1 -> if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
                               context.getColor(android.R.color.system_accent1_500)
                           } else {
-                              android.graphics.Color.CYAN
+                              context.getColor(R.color.widget_fallback_cyan)
                           }
                      2 -> {
                           val r = prefs.getInt("bg_color_r", 255)
@@ -334,7 +334,7 @@ class AwidgetProvider : AppWidgetProvider() {
                           val b = prefs.getInt("bg_color_b", 255)
                           android.graphics.Color.rgb(r, g, b)
                      }
-                     else -> if (isLight) android.graphics.Color.WHITE else android.graphics.Color.parseColor("#212121")
+                     else -> if (isLight) android.graphics.Color.WHITE else context.getColor(R.color.widget_bg_dark)
                  }
             }
 
@@ -355,7 +355,7 @@ class AwidgetProvider : AppWidgetProvider() {
                      1 -> if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
                               context.getColor(android.R.color.system_accent1_500)
                           } else {
-                              android.graphics.Color.CYAN
+                              context.getColor(R.color.widget_fallback_cyan)
                           }
                      2 -> {
                           val r = prefs.getInt("outline_color_r", 255)
@@ -412,17 +412,17 @@ class AwidgetProvider : AppWidgetProvider() {
                         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
                             context.getColor(android.R.color.system_accent2_500)
                         } else {
-                            android.graphics.Color.YELLOW
+                            context.getColor(R.color.widget_fallback_yellow)
                         }
                     }
-                    else -> if (useLightTheme) android.graphics.Color.parseColor("#AA555544") else android.graphics.Color.parseColor("#BBDDDDCC")
+                    else -> if (useLightTheme) context.getColor(R.color.widget_date_light) else context.getColor(R.color.widget_date_dark)
                 }
             }
             val alarmColor = if (useDynamicColors && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
                 // Cool tertiary accent for alarm
                 context.getColor(if (useLightTheme) android.R.color.system_accent3_700 else android.R.color.system_accent3_100)
             } else {
-                if (useLightTheme) android.graphics.Color.parseColor("#AA445566") else android.graphics.Color.parseColor("#BBAACCDD")
+                if (useLightTheme) context.getColor(R.color.widget_alarm_light) else context.getColor(R.color.widget_alarm_dark)
             }
 
             // Background & outline dynamic color

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -5,4 +5,13 @@
     <!-- Light Theme Colors -->
     <color name="widget_text_light">#FF1C1B1F</color>
     <color name="widget_text_secondary_light">#FF49454F</color>
+
+    <!-- Widget Colors -->
+    <color name="widget_bg_dark">#212121</color>
+    <color name="widget_date_light">#AA555544</color>
+    <color name="widget_date_dark">#BBDDDDCC</color>
+    <color name="widget_alarm_light">#AA445566</color>
+    <color name="widget_alarm_dark">#BBAACCDD</color>
+    <color name="widget_fallback_cyan">#00FFFF</color>
+    <color name="widget_fallback_yellow">#FFFF00</color>
 </resources>


### PR DESCRIPTION
Extract hardcoded colors to colors.xml

- Moved hardcoded hex colors and fallback constants from AwidgetProvider.kt to res/values/colors.xml
- Replaced inline color references with context.getColor() in Kotlin code to improve maintainability

---
*PR created automatically by Jules for task [5550438974200553453](https://jules.google.com/task/5550438974200553453) started by @LeanBitLab*