### PR TITLE
🧹 Remove unused import in ColorResolverTest

### DIFF
--- a/app/src/test/java/com/leanbitlab/lwidget/ColorResolverTest.kt
+++ b/app/src/test/java/com/leanbitlab/lwidget/ColorResolverTest.kt
@@ -6,7 +6,6 @@ import android.graphics.Color
 import android.os.Build
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 


### PR DESCRIPTION
🎯 **What:** Removed an unused import (`org.mockito.kotlin.any`) in `app/src/test/java/com/leanbitlab/lwidget/ColorResolverTest.kt`.
💡 **Why:** Unused imports clutter the codebase and can occasionally lead to confusion or slower compilation times. Removing them improves general code hygiene and readability.
✅ **Verification:** Verified the change by running the test suite (`./gradlew :app:testDebugUnitTest --tests "com.leanbitlab.lwidget.ColorResolverTest"`) which passed successfully. Code review confirmed the fix is correct and introduces zero regressions.
✨ **Result:** A slightly cleaner and better-maintained test file.

---
*PR created automatically by Jules for task [17423548419368700847](https://jules.google.com/task/17423548419368700847) started by @LeanBitLab*