### PR TITLE
🧹 [Code Health] Remove unused ConnectivityManager import

### DIFF
--- a/app/src/main/java/com/leanbitlab/lwidget/AwidgetProvider.kt
+++ b/app/src/main/java/com/leanbitlab/lwidget/AwidgetProvider.kt
@@ -26,7 +26,6 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.app.usage.NetworkStatsManager
 import android.os.BatteryManager


### PR DESCRIPTION
🎯 **What:** Removed unused `android.net.ConnectivityManager` import from `AwidgetProvider.kt`.
💡 **Why:** This improves the code health by reducing unused imports. It is a straightforward clean-up that doesn't affect functionality.
✅ **Verification:** Verified that `./gradlew check` and `./gradlew test` pass.
✨ **Result:** Cleaned up unused import, improving code readability.

---
*PR created automatically by Jules for task [409692446894035044](https://jules.google.com/task/409692446894035044) started by @LeanBitLab*