### PR TITLE
🧪 Add tests for boundary color indices in ColorResolver

### DIFF
--- a/app/src/test/java/com/leanbitlab/lwidget/ColorResolverTest.kt
+++ b/app/src/test/java/com/leanbitlab/lwidget/ColorResolverTest.kt
@@ -283,4 +283,76 @@ class ColorResolverTest {
 
         assertEquals(Color.parseColor("#CCFFFFFF"), result)
     }
+
+    @Test
+    fun testResolveColor_NegativeIdx_Primary() {
+        val mockContext = mock<Context>()
+        val mockPrefs = mock<SharedPreferences>()
+
+        val result = ColorResolver.resolveColor(
+            context = mockContext,
+            prefs = mockPrefs,
+            useDynamicColors = false,
+            idx = -1,
+            isPrimary = true,
+            isLight = true,
+            sdkInt = Build.VERSION_CODES.S
+        )
+
+        assertEquals(Color.WHITE, result)
+    }
+
+    @Test
+    fun testResolveColor_NegativeIdx_Secondary() {
+        val mockContext = mock<Context>()
+        val mockPrefs = mock<SharedPreferences>()
+
+        val result = ColorResolver.resolveColor(
+            context = mockContext,
+            prefs = mockPrefs,
+            useDynamicColors = false,
+            idx = -999,
+            isPrimary = false,
+            isLight = false,
+            sdkInt = Build.VERSION_CODES.S
+        )
+
+        assertEquals(Color.parseColor("#CCFFFFFF"), result)
+    }
+
+    @Test
+    fun testResolveColor_MaxIntIdx_Primary() {
+        val mockContext = mock<Context>()
+        val mockPrefs = mock<SharedPreferences>()
+
+        val result = ColorResolver.resolveColor(
+            context = mockContext,
+            prefs = mockPrefs,
+            useDynamicColors = false,
+            idx = Int.MAX_VALUE,
+            isPrimary = true,
+            isLight = true,
+            sdkInt = Build.VERSION_CODES.S
+        )
+
+        assertEquals(Color.WHITE, result)
+    }
+
+    @Test
+    fun testResolveColor_MinIntIdx_Secondary() {
+        val mockContext = mock<Context>()
+        val mockPrefs = mock<SharedPreferences>()
+
+        val result = ColorResolver.resolveColor(
+            context = mockContext,
+            prefs = mockPrefs,
+            useDynamicColors = false,
+            idx = Int.MIN_VALUE,
+            isPrimary = false,
+            isLight = true,
+            sdkInt = Build.VERSION_CODES.S
+        )
+
+        assertEquals(Color.parseColor("#CCFFFFFF"), result)
+    }
 }


### PR DESCRIPTION
🎯 **What:** Adds unit tests to `ColorResolverTest.kt` to cover unexpected and boundary values for the color index (`idx`) argument passed to `ColorResolver.resolveColor()`.
📊 **Coverage:** Specifically tests negative values (`-1`, `-999`) and boundary integer values (`Int.MAX_VALUE`, `Int.MIN_VALUE`).
✨ **Result:** Ensures the fallback `else` branch in `ColorResolver` correctly handles unexpected indices, improving test coverage for boundary inputs.

---
*PR created automatically by Jules for task [2375733997746602411](https://jules.google.com/task/2375733997746602411) started by @LeanBitLab*