### PR TITLE
🧹 Refactor hardcoded Log Tag to constant

### DIFF
--- a/app/src/main/java/com/leanbitlab/lwidget/AwidgetProvider.kt
+++ b/app/src/main/java/com/leanbitlab/lwidget/AwidgetProvider.kt
@@ -165,6 +165,8 @@ class AwidgetProvider : AppWidgetProvider() {
 
     companion object {
 
+        private const val TAG = "WidgetLife"
+
         private var cachedLocale: java.util.Locale? = null
         private val formatters = java.util.concurrent.ConcurrentHashMap<String, java.time.format.DateTimeFormatter>()
 
@@ -239,7 +241,7 @@ class AwidgetProvider : AppWidgetProvider() {
             val bweather = com.leanbitlab.lwidget.weather.BreezyWeatherFetcher.fetchLocalWeather(context)
             val showWeatherIconOnly = prefs.getBoolean("show_weather_icon_only", false) 
             
-            android.util.Log.d("WidgetLife", "UpdateMode FULL | Condition: $showWeatherCondition | IconOnly: $showWeatherIconOnly | WeatherData: ${bweather?.currentCondition}")
+            android.util.Log.d(TAG, "UpdateMode FULL | Condition: $showWeatherCondition | IconOnly: $showWeatherIconOnly | WeatherData: ${bweather?.currentCondition}")
 
             val useSystemTheme = prefs.getBoolean("use_system_theme", false)
             val useDynamicColors = prefs.getBoolean("use_dynamic_colors", true)


### PR DESCRIPTION
🎯 **What:** Extracted the hardcoded string `"WidgetLife"` to a `private const val TAG` within the `companion object` of `AwidgetProvider.kt`.
💡 **Why:** This improves maintainability by centralizing the tag definition, preventing typos, and adhering to standard Kotlin/Android logging conventions.
✅ **Verification:** Verified by running Android lint (`./gradlew lint`), unit tests (`./gradlew testDebugUnitTest`), and ensuring a successful debug build (`./gradlew assembleDebug`).
✨ **Result:** Improved code cleanliness without changing any functional behavior.

---
*PR created automatically by Jules for task [4894139533681723766](https://jules.google.com/task/4894139533681723766) started by @LeanBitLab*